### PR TITLE
Fix diagnostics

### DIFF
--- a/include/twist_mux/twist_mux.h
+++ b/include/twist_mux/twist_mux.h
@@ -52,7 +52,7 @@ public:
   typedef std::list<VelocityTopicHandle> velocity_topic_container;
   typedef std::list<LockTopicHandle>     lock_topic_container;
 
-  TwistMux(int window_size = 10);
+  TwistMux();
   ~TwistMux();
 
   bool hasPriority(const VelocityTopicHandle& twist);

--- a/include/twist_mux/twist_mux_diagnostics.h
+++ b/include/twist_mux/twist_mux_diagnostics.h
@@ -44,7 +44,7 @@ class TwistMuxDiagnostics
 
     void diagnostics(diagnostic_updater::DiagnosticStatusWrapper& stat);
 
-    void update();
+    void update(const bool force_update = false);
 
     void updateStatus(const status_type::ConstPtr& status);
 

--- a/include/twist_mux/twist_mux_diagnostics.h
+++ b/include/twist_mux/twist_mux_diagnostics.h
@@ -36,9 +36,6 @@ class TwistMuxDiagnostics
   public:
     typedef TwistMuxDiagnosticsStatus status_type;
 
-    static constexpr double MAIN_LOOP_TIME_MIN = 0.2; // [s]
-    static constexpr double READING_AGE_MIN    = 3.0; // [s]
-
     TwistMuxDiagnostics();
     virtual ~TwistMuxDiagnostics();
 

--- a/include/twist_mux/twist_mux_diagnostics_status.h
+++ b/include/twist_mux/twist_mux_diagnostics_status.h
@@ -34,20 +34,13 @@ struct TwistMuxDiagnosticsStatus
   typedef boost::shared_ptr<TwistMuxDiagnosticsStatus> Ptr;
   typedef boost::shared_ptr<const TwistMuxDiagnosticsStatus> ConstPtr;
 
-  double reading_age;
-  ros::Time last_loop_update;
-  double main_loop_time;
-
   LockTopicHandle::priority_type priority;
 
   boost::shared_ptr<TwistMux::velocity_topic_container> velocity_hs;
   boost::shared_ptr<TwistMux::lock_topic_container>     lock_hs;
 
   TwistMuxDiagnosticsStatus()
-    : reading_age(0),
-      last_loop_update(ros::Time::now()),
-      main_loop_time(0),
-      priority(0)
+    : priority(0)
   {
   }
 };

--- a/src/twist_mux.cpp
+++ b/src/twist_mux.cpp
@@ -48,7 +48,7 @@ bool hasIncreasedAbsVelocity(const geometry_msgs::Twist& old_twist, const geomet
 namespace twist_mux
 {
 
-TwistMux::TwistMux(int window_size)
+TwistMux::TwistMux()
 {
   ros::NodeHandle nh;
   ros::NodeHandle nh_priv("~");

--- a/src/twist_mux.cpp
+++ b/src/twist_mux.cpp
@@ -125,7 +125,7 @@ int TwistMux::getLockPriority()
   {
     if (lock_h.isLocked())
     {
-      auto tmp = lock_h.getPriority();
+      const auto tmp = lock_h.getPriority();
       if (priority < tmp)
       {
         priority = tmp;

--- a/src/twist_mux_diagnostics.cpp
+++ b/src/twist_mux_diagnostics.cpp
@@ -55,21 +55,12 @@ void TwistMuxDiagnostics::updateStatus(const status_type::ConstPtr& status)
   status_.lock_hs     = status->lock_hs;
   status_.priority    = status->priority;
 
-  status_.main_loop_time = status->main_loop_time;
-  status_.reading_age    = status->reading_age;
-
   update();
 }
 
 void TwistMuxDiagnostics::diagnostics(diagnostic_updater::DiagnosticStatusWrapper& stat)
 {
-  /// Check if the loop period is quick enough
-  if (status_.main_loop_time > MAIN_LOOP_TIME_MIN)
-    stat.summary(ERROR, "loop time too long");
-  else if (status_.reading_age > READING_AGE_MIN)
-    stat.summary(ERROR, "data received is too old");
-  else
-    stat.summary(OK, "ok");
+  stat.summary(OK, "ok");
 
   for (const auto& velocity_h : *status_.velocity_hs)
   {
@@ -91,10 +82,7 @@ void TwistMuxDiagnostics::diagnostics(diagnostic_updater::DiagnosticStatusWrappe
               static_cast<int>(lock_h.getPriority()));
   }
 
-  stat.add("current priority", static_cast<int>(status_.priority));
-
-  stat.add("loop time in [sec]", status_.main_loop_time);
-  stat.add("data age in [sec]", status_.reading_age);
+  stat.add("current lock priority", static_cast<int>(status_.priority));
 
   ROS_DEBUG_THROTTLE(1.0, "Publishing diagnostics.");
 }

--- a/src/twist_mux_diagnostics.cpp
+++ b/src/twist_mux_diagnostics.cpp
@@ -35,9 +35,16 @@ TwistMuxDiagnostics::TwistMuxDiagnostics()
 TwistMuxDiagnostics::~TwistMuxDiagnostics()
 {}
 
-void TwistMuxDiagnostics::update()
+void TwistMuxDiagnostics::update(const bool force_update)
 {
-  diagnostic_.update();
+  if (force_update)
+  {
+    diagnostic_.force_update();
+  }
+  else
+  {
+    diagnostic_.update();
+  }
 }
 
 void TwistMuxDiagnostics::updateStatus(const status_type::ConstPtr& status)

--- a/src/twist_mux_diagnostics.cpp
+++ b/src/twist_mux_diagnostics.cpp
@@ -51,11 +51,18 @@ void TwistMuxDiagnostics::updateStatus(const status_type::ConstPtr& status)
 {
   ROS_DEBUG_THROTTLE(1.0, "Updating status.");
 
+  const bool has_status_changed =
+    // @todo the comparison between vectors to lists is failing,
+    // or for the internal elements!
+    //*(status_.velocity_hs) != *(status->velocity_hs) ||
+    //*(status_.lock_hs)     != *(status->lock_hs)     ||
+     status_.priority    !=  status->priority;
+
   status_.velocity_hs = status->velocity_hs;
   status_.lock_hs     = status->lock_hs;
   status_.priority    = status->priority;
 
-  update();
+  update(has_status_changed);
 }
 
 void TwistMuxDiagnostics::diagnostics(diagnostic_updater::DiagnosticStatusWrapper& stat)


### PR DESCRIPTION
This basically remove old/deprecated variables and diagnostics from an old non-asynchronous implementation.

Note that the last commit is sort of WIP, or could be addressed later.

This addresses #5 

@ipa-fxm @bmagyar 
