### PR TITLE
Add flag functionality to every topic and lock. Carries extra info.

### DIFF
--- a/config/twist_mux_locks.yaml
+++ b/config/twist_mux_locks.yaml
@@ -7,6 +7,7 @@
 #                       to detect that, and if the publisher dies we will enable the lock
 # - priority: priority in the range [0, 255], so all the topics with priority lower than it
 #             will be stopped/disabled
+# - flag: flag in the range [128, 255], (...)
 
 locks:
 -
@@ -15,14 +16,17 @@ locks:
   timeout : 0.0
   # Same priority as joystick control, so it'll not block it.
   priority: 100
+  flag    : 128
 -
   name    : loop_closure
   topic   : stop_closing_loop
   timeout : 0.0
   priority: 200
+  flag    : 128
 -
   name    : joystick 
   topic   : joy_priority
   timeout : 0.0
   priority: 100
+  flag    : 128
 

--- a/config/twist_mux_topics.yaml
+++ b/config/twist_mux_topics.yaml
@@ -4,6 +4,7 @@
 # - topic   : input topic of geometry_msgs::Twist type
 # - timeout : timeout in seconds to start discarding old messages, and use 0.0 speed instead
 # - priority: priority in the range [0, 255]; the higher the more priority over other topics
+# - flag    : flags the cmd_vel type [0, 127]; (0 - auto /// 1 - user /// 2 - sudo /// ...)
 
 topics:
 -
@@ -11,18 +12,22 @@ topics:
   topic   : nav_vel
   timeout : 0.5
   priority: 10
+  flag    : 0
 -
   name    : joystick
   topic   : joy_vel
   timeout : 0.5
   priority: 100
+  flag    : 2
 -
   name    : keyboard
   topic   : key_vel
   timeout : 0.5
   priority: 90
+  flag    : 1
 -
   name    : tablet
   topic   : tab_vel
   timeout : 0.5
   priority: 100
+  flag    : 1

--- a/launch/twist_mux.launch
+++ b/launch/twist_mux.launch
@@ -3,6 +3,7 @@
   <arg name="joy_vel_out" default="joy_vel"/>
 
   <arg name="cmd_vel_out" default="twist_mux/cmd_vel"/>
+  <arg name="flag_name" default="flag"/>
 
   <arg name="config_locks"  default="$(find twist_mux)/config/twist_mux_locks.yaml"/>
   <arg name="config_topics" default="$(find twist_mux)/config/twist_mux_topics.yaml"/>
@@ -11,6 +12,7 @@
 
   <node pkg="twist_mux" type="twist_mux" name="twist_mux" output="screen">
     <remap from="cmd_vel_out" to="$(arg cmd_vel_out)"/>
+    <remap from="flag" to="$(arg flag_name)"/>
 
     <rosparam file="$(arg config_locks)"  command="load"/>
     <rosparam file="$(arg config_topics)" command="load"/>

--- a/src/twist_mux.cpp
+++ b/src/twist_mux.cpp
@@ -97,6 +97,7 @@ void TwistMux::getTopicHandles(ros::NodeHandle& nh, ros::NodeHandle& nh_priv, co
     std::string name, topic;
     double timeout;
     int priority;
+    int flag;
     for (int i = 0; i < output.size(); ++i)
     {
       xh::getArrayItem(output, i, output_i);
@@ -105,8 +106,9 @@ void TwistMux::getTopicHandles(ros::NodeHandle& nh, ros::NodeHandle& nh_priv, co
       xh::getStructMember(output_i, "topic"   , topic   );
       xh::getStructMember(output_i, "timeout" , timeout );
       xh::getStructMember(output_i, "priority", priority);
+      xh::getStructMember(output_i, "flag"    , flag);
 
-      topic_hs.emplace_back(nh, name, topic, timeout, priority, this);
+      topic_hs.emplace_back(nh, name, topic, timeout, priority, flag, this);
     }
   }
   catch (const xh::XmlrpcHelperException& e)


### PR DESCRIPTION
Implemented a flag functionality that allows to more easily identify the type of velocity/lock that is being picked and sent by the multiplexer. This is particularly useful, when you want to identify a particular robot state, through its velocity commands' source (for instance, autonomous vs. manual operation). Or even, just the command velocity (the one picked by the multiplexer) itself.

**How this feature works:**
1 - You flag your input topics following some case-specific criteria.
2 - Listen to the new **UInt8 flag topic** (*/flag* by default).
2 - Now you know which (type of) topic was picked.
3 - Decide *(1)* what to do with that information...

*(1)* Decision making