### PR TITLE
Publish zero if locked

### DIFF
--- a/config/twist_mux_topics.yaml
+++ b/config/twist_mux_topics.yaml
@@ -4,6 +4,7 @@
 # - topic   : input topic of geometry_msgs::Twist type
 # - timeout : timeout in seconds to start discarding old messages, and use 0.0 speed instead
 # - priority: priority in the range [0, 255]; the higher the more priority over other topics
+# - pub_zero_if_locked: if true, publish 0.0 command if the topic is locked
 
 twist_mux:
   ros__parameters:
@@ -12,15 +13,19 @@ twist_mux:
         topic   : nav_vel
         timeout : 0.5
         priority: 10
+        pub_zero_if_locked: false
       joystick:
         topic   : joy_vel
         timeout : 0.5
         priority: 100
+        pub_zero_if_locked: false
       keyboard:
         topic   : key_vel
         timeout : 0.5
         priority: 90
+        pub_zero_if_locked: false
       tablet:
         topic   : tab_vel
         timeout : 0.5
         priority: 100
+        pub_zero_if_locked: false

--- a/include/twist_mux/topic_handle.hpp
+++ b/include/twist_mux/topic_handle.hpp
@@ -189,12 +189,18 @@ public:
     stamp_ = mux_->now();
     msg_ = *msg;
 
+    // If topic locked, overide with zero twist
+    const auto lock_priority = mux_->getLockPriority();
+    if (getPriority() < lock_priority) {
+      msg_ = geometry_msgs::msg::Twist();
+    }
+
     // Check if this twist has priority.
     // Note that we have to check all the locks because they might time out
     // and since we have several topics we must look for the highest one in
     // all the topic list; so far there's no O(1) solution.
     if (mux_->hasPriority(*this)) {
-      mux_->publishTwist(msg);
+      mux_->publishTwist(msg_);
     }
   }
 };

--- a/include/twist_mux/twist_mux.hpp
+++ b/include/twist_mux/twist_mux.hpp
@@ -73,9 +73,11 @@ public:
 
   bool hasPriority(const VelocityTopicHandle & twist);
 
-  void publishTwist(const geometry_msgs::msg::Twist::ConstSharedPtr & msg);
+  void publishTwist(const geometry_msgs::msg::Twist & msg);
 
   void updateDiagnostics();
+
+  int getLockPriority();
 
 protected:
   typedef TwistMuxDiagnostics diagnostics_type;
@@ -100,8 +102,6 @@ protected:
 
   template<typename T>
   void getTopicHandles(const std::string & param_name, handle_container<T> & topic_hs);
-
-  int getLockPriority();
 
   std::shared_ptr<diagnostics_type> diagnostics_;
   std::shared_ptr<status_type> status_;

--- a/src/twist_mux.cpp
+++ b/src/twist_mux.cpp
@@ -107,9 +107,9 @@ void TwistMux::updateDiagnostics()
   diagnostics_->updateStatus(status_);
 }
 
-void TwistMux::publishTwist(const geometry_msgs::msg::Twist::ConstSharedPtr & msg)
+void TwistMux::publishTwist(const geometry_msgs::msg::Twist & msg)
 {
-  cmd_pub_->publish(*msg);
+  cmd_pub_->publish(msg);
 }
 
 template<typename T>
@@ -167,15 +167,13 @@ int TwistMux::getLockPriority()
 
 bool TwistMux::hasPriority(const VelocityTopicHandle & twist)
 {
-  const auto lock_priority = getLockPriority();
-
   LockTopicHandle::priority_type priority = 0;
   std::string velocity_name = "NULL";
 
   /// max_element on the priority of velocity topic handles satisfying
   /// that is NOT masked by the lock priority:
   for (const auto & velocity_h : *velocity_hs_) {
-    if (!velocity_h.isMasked(lock_priority)) {
+    if (!velocity_h.hasExpired()) {
       const auto velocity_priority = velocity_h.getPriority();
       if (priority < velocity_priority) {
         priority = velocity_priority;

--- a/src/twist_mux.cpp
+++ b/src/twist_mux.cpp
@@ -126,18 +126,26 @@ void TwistMux::getTopicHandles(const std::string & param_name, std::list<T> & to
       std::string topic;
       double timeout = 0;
       int priority = 0;
+      bool pub_zero_if_locked = false;
 
       auto nh = std::shared_ptr<rclcpp::Node>(this, [](rclcpp::Node *) {});
 
       fetch_param(nh, prefix + ".topic", topic);
       fetch_param(nh, prefix + ".timeout", timeout);
       fetch_param(nh, prefix + ".priority", priority);
+      try {
+        fetch_param(nh, prefix + ".pub_zero_if_locked", pub_zero_if_locked);
+      } catch (...) {
+      }
 
       RCLCPP_DEBUG(get_logger(), "Retrieved topic: %s", topic.c_str());
       RCLCPP_DEBUG(get_logger(), "Listed prefix: %.2f", timeout);
       RCLCPP_DEBUG(get_logger(), "Listed prefix: %d", priority);
+      RCLCPP_DEBUG(get_logger(), "Listed prefix: %d", pub_zero_if_locked);
 
-      topic_hs.emplace_back(prefix, topic, std::chrono::duration<double>(timeout), priority, this);
+      topic_hs.emplace_back(
+        prefix, topic, std::chrono::duration<double>(
+          timeout), priority, pub_zero_if_locked, this);
     }
   } catch (const ParamsHelperException & e) {
     RCLCPP_FATAL(get_logger(), "Error parsing params '%s':\n\t%s", param_name.c_str(), e.what());


### PR DESCRIPTION
Hi,

I found that when a topic is locked, the mux just stops publishing. This means that our robot depends on another timeout to stop (the smoother in our case).
![twist_mux_lock_timout](https://user-images.githubusercontent.com/48433002/235676321-25c4c68f-9a0e-441e-826a-8a0b988b57cf.png)

So I made a small modification to publish zero twists when the topic that has priority is locked.

To do so, I moved the lock check in the topic callback. If the topic is locked, I replace the message with `geometry_msgs::msg::Twist()`. If this topic has priority, the zero twist value will be published.

Hence the robot starts to brake immediately.