### PR TITLE
Joystick relay for ROS 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,11 +47,10 @@ install(
   RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
-# Pending to test ROS2 migration
-#install(
-#  PROGRAMS scripts/joystick_relay.py
-#  DESTINATION lib/${PROJECT_NAME}
-#)
+install(
+  PROGRAMS scripts/joystick_relay.py
+  DESTINATION lib/${PROJECT_NAME}
+)
 
 foreach(dir launch config)
   install(DIRECTORY ${dir}/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ install(
 if(BUILD_TESTING)
   find_package(launch_testing_ament_cmake)
   add_launch_test(test/test_joystick_relay.py)
+  add_launch_test(test/system.test.py)
 endif()
 
 ament_export_include_directories(include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,8 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  #  find_package(launch_testing_ament_cmake)
+  find_package(launch_testing_ament_cmake)
+  add_launch_test(test/test_joystick_relay.py)
   #  add_launch_test(test/system.test.py)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,6 @@ install(
 if(BUILD_TESTING)
   find_package(launch_testing_ament_cmake)
   add_launch_test(test/test_joystick_relay.py)
-  add_launch_test(test/system.test.py)
 endif()
 
 ament_export_include_directories(include)

--- a/launch/twist_mux_launch.py
+++ b/launch/twist_mux_launch.py
@@ -55,8 +55,7 @@ def generate_launch_description():
             remappings={('/cmd_vel_out', LaunchConfiguration('cmd_vel_out'))},
             parameters=[
                 LaunchConfiguration('config_locks'),
-                LaunchConfiguration('config_topics'),
-                LaunchConfiguration('config_joy')]
+                LaunchConfiguration('config_topics')]
         ),
         Node(
             package='twist_mux',

--- a/launch/twist_mux_launch.py
+++ b/launch/twist_mux_launch.py
@@ -58,7 +58,6 @@ def generate_launch_description():
                 LaunchConfiguration('config_topics'),
                 LaunchConfiguration('config_joy')]
         ),
-
         Node(
             package='twist_mux',
             executable='twist_marker',
@@ -67,5 +66,12 @@ def generate_launch_description():
             parameters=[{
                 'frame_id': 'base_link',
                 'scale': 1.0,
-                'vertical_position': 2.0}])
-            ])
+                'vertical_position': 2.0}]),
+        Node(
+            package='twist_mux',
+            executable='joystick_relay.py',
+            output='screen',
+            remappings={('joy_vel_in', 'input_joy/cmd_vel'),
+                        ('joy_vel_out', 'joy_vel')},
+            parameters=[LaunchConfiguration('config_joy')])
+    ])

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,8 @@
   <depend>visualization_msgs</depend>
   <depend>diagnostic_updater</depend>
 
+  <exec_depend>twist_mux_msgs</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
 
   <test_depend>ament_cmake_xmllint</test_depend>

--- a/scripts/joystick_relay.py
+++ b/scripts/joystick_relay.py
@@ -29,6 +29,7 @@ import numpy as np
 
 from geometry_msgs.msg import Twist
 from rclpy.action import ActionServer
+from rclpy.qos import QoSProfile, QoSDurabilityPolicy
 from rclpy.node import Node
 from std_msgs.msg import Bool
 from twist_mux_msgs.action import JoyPriority, JoyTurbo
@@ -75,7 +76,7 @@ class ServiceLikeActionServer(object):
     def _cb(self, goal):
         self._callback()
         goal.succeed()
-        return self._action_type().Result()
+        return self._action_type.Result()
 
 
 class VelocityControl:
@@ -88,35 +89,35 @@ class VelocityControl:
             'turbo/linear_forward_min', 1.0)
         forward_max = self._node.declare_parameter(
             'turbo/linear_forward_max', 1.0)
-        self._forward = Velocity(forward_min, forward_max, self._num_steps)
+        self._forward = Velocity(forward_min.value, forward_max.value, self._num_steps.value)
 
         backward_min = self._node.declare_parameter(
-            'turbo/linear_backward_min', forward_min)
+            'turbo/linear_backward_min', forward_min.value)
         backward_max = self._node.declare_parameter(
-            'turbo/linear_backward_max', forward_max)
-        self._backward = Velocity(backward_min, backward_max, self._num_steps)
+            'turbo/linear_backward_max', forward_max.value)
+        self._backward = Velocity(backward_min.value, backward_max.value, self._num_steps.value)
 
         lateral_min = self._node.declare_parameter(
             'turbo/linear_lateral_min', 1.0)
         lateral_max = self._node.declare_parameter(
             'turbo/linear_lateral_max', 1.0)
-        self._lateral = Velocity(lateral_min, lateral_max, self._num_steps)
+        self._lateral = Velocity(lateral_min.value, lateral_max.value, self._num_steps.value)
 
         angular_min = self._node.declare_parameter('turbo/angular_min', 1.0)
         angular_max = self._node.declare_parameter('turbo/angular_max', 1.0)
-        self._angular = Velocity(angular_min, angular_max, self._num_steps)
+        self._angular = Velocity(angular_min.value, angular_max.value, self._num_steps.value)
 
-        default_init_step = np.floor((self._num_steps + 1)/2.0)
+        default_init_step = np.floor((self._num_steps.value + 1)/2.0)
         init_step = self._node.declare_parameter(
             'turbo/init_step', default_init_step)
 
-        if init_step < 0 or init_step > self._num_steps:
+        if init_step.value < 0 or init_step.value > self._num_steps.value:
             self._init_step = default_init_step
             self._node.get_logger().warn('Initial step %d outside range [1, %d]!'
                                          ' Falling back to default %d' %
-                                         (init_step, self._num_steps, default_init_step))
+                                         (init_step.value, self._num_steps.value, default_init_step))
         else:
-            self._init_step = init_step
+            self._init_step = init_step.value
 
         self.reset_turbo()
 
@@ -148,7 +149,7 @@ class VelocityControl:
         return twist
 
     def increase_turbo(self):
-        if self._current_step < self._num_steps:
+        if self._current_step < self._num_steps.value:
             self._current_step += 1
         self.increase_angular_turbo()
 
@@ -158,7 +159,7 @@ class VelocityControl:
         self.decrease_angular_turbo()
 
     def increase_angular_turbo(self):
-        if self._current_angular_step < self._num_steps:
+        if self._current_angular_step < self._num_steps.value:
             self._current_angular_step += 1
 
     def decrease_angular_turbo(self):
@@ -173,8 +174,11 @@ class VelocityControl:
 class TextMarker(object):
 
     def __init__(self, node, scale=1.0, z=0.0):
-        # TODO latch
-        self._pub = node.create_publisher(Marker, 'text_marker', 1)
+        self._pub = node.create_publisher(
+            Marker, 'text_marker', QoSProfile(
+                durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+                depth=1)
+        )
 
         self._scale = scale
         self._z = z
@@ -214,8 +218,9 @@ class JoystickRelay(Node):
     def __init__(self):
         super().__init__('joystick_relay')
 
-        self._current_priority = self.declare_parameter('priority', True)
-        self._velocity_control = VelocityControl()
+        self._current_priority = Bool()
+        self._current_priority.data = self.declare_parameter('priority', True).value
+        self._velocity_control = VelocityControl(self)
 
         self._marker = TextMarker(self, 0.5, 2.0)
 
@@ -223,12 +228,15 @@ class JoystickRelay(Node):
         self._subscriber = self.create_subscription(
             Twist, 'joy_vel_in', self._forward_cmd, 1)
 
-        # TODO Latch
-        self._pub_priority = self.create_publisher(Bool, 'joy_priority', 1)
+        self._pub_priority = self.create_publisher(
+            Bool, 'joy_priority', QoSProfile(
+                durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+                depth=1)
+        )
 
         # Wait for subscribers and publish initial joy_priority:
         self._pub_priority.publish(self._current_priority)
-        self._marker.update(self._current_priority)
+        self._marker.update(self._current_priority.data)
 
         # Marker timer (required to update the marker when the robot doesn't receive velocities):
         self._timer = self.create_timer(1.0, self._timer_callback)
@@ -255,24 +263,24 @@ class JoystickRelay(Node):
             self._velocity_control.reset_turbo)
 
     def _forward_cmd(self, cmd):
-        if self._current_priority:
+        if self._current_priority.data:
             self._pub_cmd.publish(self._velocity_control.scale_twist(cmd))
 
-        self._marker.update(self._current_priority)
+        self._marker.update(self._current_priority.data)
 
     def _toggle_priority(self):
-        self._current_priority = not self._current_priority
-        self.get_logger().info("Toggled joy_priority, current status is: %s",
-                               self._current_priority)
+        self._current_priority.data = not self._current_priority.data
+        self.get_logger().info("Toggled joy_priority, current status is: %s" %
+                               (self._current_priority.data))
         self._pub_priority.publish(self._current_priority)
-        self._marker.update(self._current_priority)
+        self._marker.update(self._current_priority.data)
 
         # Reset velocity to 0:
-        if self._current_priority:
+        if self._current_priority.data:
             self._pub_cmd.publish(Twist())
 
-    def _timer_callback(self, event):
-        self._marker.update(self._current_priority)
+    def _timer_callback(self):
+        self._marker.update(self._current_priority.data)
 
 
 def main(args=None):

--- a/scripts/joystick_relay.py
+++ b/scripts/joystick_relay.py
@@ -29,6 +29,7 @@ import numpy as np
 
 from geometry_msgs.msg import Twist
 from rclpy.action import ActionServer
+from rclpy.executors import ExternalShutdownException
 from rclpy.qos import QoSProfile, QoSDurabilityPolicy
 from rclpy.node import Node
 from std_msgs.msg import Bool
@@ -288,10 +289,13 @@ def main(args=None):
 
     node = JoystickRelay()
 
-    rclpy.spin(node)
-
-    node.destroy_node()
-    rclpy.shutdown()
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/scripts/joystick_relay.py
+++ b/scripts/joystick_relay.py
@@ -114,9 +114,9 @@ class VelocityControl:
 
         if init_step.value < 0 or init_step.value > self._num_steps.value:
             self._init_step = default_init_step
-            self._node.get_logger().warn('Initial step %d outside range [1, %d]!'
-                                         ' Falling back to default %d' %
-                                         (init_step.value, self._num_steps.value, default_init_step))
+            self._node.get_logger().warn(
+                'Initial step %d outside range [1, %d]! Falling back to default %d' %
+                (init_step.value, self._num_steps.value, default_init_step))
         else:
             self._init_step = init_step.value
 

--- a/scripts/joystick_relay.py
+++ b/scripts/joystick_relay.py
@@ -83,33 +83,33 @@ class VelocityControl:
 
     def __init__(self, node):
         self._node = node
-        self._num_steps = self._node.declare_parameter('turbo/steps', 1)
+        self._num_steps = self._node.declare_parameter('turbo.steps', 1)
 
         forward_min = self._node.declare_parameter(
-            'turbo/linear_forward_min', 1.0)
+            'turbo.linear_forward_min', 1.0)
         forward_max = self._node.declare_parameter(
-            'turbo/linear_forward_max', 1.0)
+            'turbo.linear_forward_max', 1.0)
         self._forward = Velocity(forward_min.value, forward_max.value, self._num_steps.value)
 
         backward_min = self._node.declare_parameter(
-            'turbo/linear_backward_min', forward_min.value)
+            'turbo.linear_backward_min', forward_min.value)
         backward_max = self._node.declare_parameter(
-            'turbo/linear_backward_max', forward_max.value)
+            'turbo.linear_backward_max', forward_max.value)
         self._backward = Velocity(backward_min.value, backward_max.value, self._num_steps.value)
 
         lateral_min = self._node.declare_parameter(
-            'turbo/linear_lateral_min', 1.0)
+            'turbo.linear_lateral_min', 1.0)
         lateral_max = self._node.declare_parameter(
-            'turbo/linear_lateral_max', 1.0)
+            'turbo.linear_lateral_max', 1.0)
         self._lateral = Velocity(lateral_min.value, lateral_max.value, self._num_steps.value)
 
-        angular_min = self._node.declare_parameter('turbo/angular_min', 1.0)
-        angular_max = self._node.declare_parameter('turbo/angular_max', 1.0)
+        angular_min = self._node.declare_parameter('turbo.angular_min', 1.0)
+        angular_max = self._node.declare_parameter('turbo.angular_max', 1.0)
         self._angular = Velocity(angular_min.value, angular_max.value, self._num_steps.value)
 
         default_init_step = np.floor((self._num_steps.value + 1)/2.0)
         init_step = self._node.declare_parameter(
-            'turbo/init_step', default_init_step)
+            'turbo.init_step', default_init_step)
 
         if init_step.value < 0 or init_step.value > self._num_steps.value:
             self._init_step = default_init_step

--- a/test/test_joystick_relay.py
+++ b/test/test_joystick_relay.py
@@ -1,0 +1,324 @@
+#! /usr/bin/python3
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2023 PAL Robotics S.L. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import launch_testing
+import rclpy
+import threading
+
+from geometry_msgs.msg import Twist
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from rclpy.action import ActionClient
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.qos import QoSProfile, QoSDurabilityPolicy
+from std_msgs.msg import Bool
+from twist_mux_msgs.action import JoyPriority, JoyTurbo
+
+MAX_VEL = 1.0
+MIN_VEL = 0.5
+STEPS = 4
+INIT_STEP = 1.0
+
+
+def generate_test_description():
+
+    joystick_relay = Node(
+      package='twist_mux',
+      executable='joystick_relay.py',
+      output='screen',
+      parameters=[{
+          'priority': True,
+          'turbo.linear_forward_min': MIN_VEL,
+          'turbo.linear_forward_max': MAX_VEL,
+          'turbo.linear_lateral_min': MIN_VEL,
+          'turbo.linear_lateral_max': MAX_VEL,
+          'turbo.linear_backward_min': MIN_VEL,
+          'turbo.linear_backward_max': MAX_VEL,
+          'turbo.angular_min': MIN_VEL,
+          'turbo.angular_max': MAX_VEL,
+          'turbo.steps': STEPS,
+          'turbo.init_step': INIT_STEP
+      }])
+
+    return LaunchDescription([
+        joystick_relay,
+        launch_testing.actions.ReadyToTest(),
+    ]), {'joystick_relay': joystick_relay}
+
+
+class TestJoystickRelay(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        rclpy.init()
+        self.node = rclpy.create_node('test_joystick_relay')
+        self.pub = self.node.create_publisher(Twist, 'joy_vel_in', rclpy.qos.QoSProfile(depth=10))
+
+    @classmethod
+    def tearDownClass(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    @classmethod
+    def setUp(self):
+        self.sub = self.node.create_subscription(
+            Twist, 'joy_vel_out', self._sub_callback, QoSProfile(depth=1))
+        self._reset_twist()
+        self.timer = self.node.create_timer(0.1, self._pub_callback)
+        self.executor = None
+        self.exec_thread = None
+
+    @classmethod
+    def tearDown(self):
+        self.timer.destroy()
+        if (self.executor is not None) and (self.exec_thread is not None):
+            self.executor.remove_node(self.node)
+            self.executor.shutdown()
+            self.exec_thread.join()
+
+        self.sub = None
+
+    @classmethod
+    def _pub_callback(self):
+        self.pub.publish(self.twist_msg)
+
+    @classmethod
+    def _sub_callback(self, msg):
+        self.current_twist = msg
+
+    @classmethod
+    def _start_spinner_thread(self):
+        self.executor = SingleThreadedExecutor()
+        self.executor.add_node(self.node)
+        self.exec_thread = threading.Thread(target=self.executor.spin)
+        self.exec_thread.start()
+
+    @classmethod
+    def _get_current_vel(self, commanded_vel, current_step):
+        vel = (MIN_VEL + (MAX_VEL - MIN_VEL) / (STEPS - 1) * (current_step - 1))
+        if (vel < MIN_VEL):
+            vel = MIN_VEL
+        elif (vel > MAX_VEL):
+            vel = MAX_VEL
+        return vel * commanded_vel
+
+    @classmethod
+    def _wait_for_twist(self):
+        # wait until all changes
+        while (self.current_twist.linear.x == 0.0 or
+               self.current_twist.linear.y == 0.0 or
+               self.current_twist.angular.z == 0.0):
+            pass
+
+    @classmethod
+    def _reset_twist(self):
+        self.twist_msg = Twist()
+        self.current_twist = Twist()
+
+    def test_joy_priority_action(self):
+        priority = None
+
+        def _priority_cb(msg):
+            nonlocal priority
+            priority = msg
+
+        def wait_for_priority(value):
+            nonlocal priority
+            while (priority is None):
+                rclpy.spin_once(self.node)
+            self.assertEqual(priority.data, value)
+            priority = None
+
+        self.node.create_subscription(Bool, 'joy_priority', _priority_cb, QoSProfile(
+            durability=QoSDurabilityPolicy.TRANSIENT_LOCAL, depth=1))
+        wait_for_priority(True)  # default one
+
+        client = ActionClient(self.node, JoyPriority, 'joy_priority_action')
+        client.wait_for_server()
+
+        client.send_goal_async(JoyPriority.Goal())
+        wait_for_priority(False)
+
+        client.send_goal_async(JoyPriority.Goal())
+        wait_for_priority(True)
+
+    def test_joy_vel(self):
+        self._start_spinner_thread()
+        self.twist_msg.linear.x = 0.5
+        self.twist_msg.linear.y = 0.8
+        self.twist_msg.angular.z = 1.0
+
+        self._wait_for_twist()
+
+        self.assertEqual(
+            self.current_twist.linear.x,
+            self._get_current_vel(self.twist_msg.linear.x, INIT_STEP))
+        self.assertEqual(
+            self.current_twist.linear.y,
+            self._get_current_vel(self.twist_msg.linear.y, INIT_STEP))
+        self.assertEqual(
+            self.current_twist.angular.z,
+            self._get_current_vel(self.twist_msg.angular.z, INIT_STEP))
+
+    def test_turbo_increase_decrease(self):
+        self._start_spinner_thread()
+
+        # Increase
+        increase_client = ActionClient(self.node, JoyTurbo, 'joy_turbo_increase')
+        increase_client.wait_for_server()
+        increase_client.send_goal(JoyTurbo.Goal())
+
+        self.twist_msg.linear.x = 0.5
+        self.twist_msg.linear.y = 0.8
+        self.twist_msg.angular.z = 1.0
+
+        self._wait_for_twist()
+
+        self.assertEqual(
+            self.current_twist.linear.x,
+            self._get_current_vel(self.twist_msg.linear.x, INIT_STEP + 1))
+        self.assertEqual(
+            self.current_twist.linear.y,
+            self._get_current_vel(self.twist_msg.linear.y, INIT_STEP + 1))
+        self.assertEqual(
+            self.current_twist.angular.z,
+            self._get_current_vel(self.twist_msg.angular.z, INIT_STEP + 1))
+
+        self._reset_twist()
+
+        # Decrease
+        decrease_client = ActionClient(self.node, JoyTurbo, 'joy_turbo_decrease')
+        decrease_client.wait_for_server()
+        decrease_client.send_goal(JoyTurbo.Goal())
+
+        self.twist_msg.linear.x = 0.5
+        self.twist_msg.linear.y = 0.8
+        self.twist_msg.angular.z = 1.0
+
+        self._wait_for_twist()
+
+        self.assertEqual(
+            self.current_twist.linear.x,
+            self._get_current_vel(self.twist_msg.linear.x, INIT_STEP))  # + 1 - 1
+        self.assertEqual(
+            self.current_twist.linear.y,
+            self._get_current_vel(self.twist_msg.linear.y, INIT_STEP))  # + 1 - 1
+        self.assertEqual(
+            self.current_twist.angular.z,
+            self._get_current_vel(self.twist_msg.angular.z, INIT_STEP))  # + 1 - 1
+
+    def test_turbo_angular_increase_decrease(self):
+        self._start_spinner_thread()
+
+        # Angular increase
+        client = ActionClient(self.node, JoyTurbo, 'joy_turbo_angular_increase')
+        client.wait_for_server()
+        client.send_goal(JoyTurbo.Goal())
+
+        self.twist_msg.linear.x = 0.5
+        self.twist_msg.linear.y = 0.8
+        self.twist_msg.angular.z = 1.0
+
+        self._wait_for_twist()
+
+        self.assertEqual(
+            self.current_twist.linear.x,
+            self._get_current_vel(self.twist_msg.linear.x, INIT_STEP))
+        self.assertEqual(
+            self.current_twist.linear.y,
+            self._get_current_vel(self.twist_msg.linear.y, INIT_STEP))
+        self.assertEqual(
+            self.current_twist.angular.z,
+            self._get_current_vel(self.twist_msg.angular.z, INIT_STEP + 1))
+
+        self._reset_twist()
+
+        # Angular decrease
+        client = ActionClient(self.node, JoyTurbo, 'joy_turbo_angular_decrease')
+        client.wait_for_server()
+        client.send_goal(JoyTurbo.Goal())
+
+        self.twist_msg.linear.x = 0.5
+        self.twist_msg.linear.y = 0.8
+        self.twist_msg.angular.z = 1.0
+
+        self._wait_for_twist()
+
+        self.assertEqual(
+            self.current_twist.linear.x,
+            self._get_current_vel(self.twist_msg.linear.x, INIT_STEP))
+        self.assertEqual(
+            self.current_twist.linear.y,
+            self._get_current_vel(self.twist_msg.linear.y, INIT_STEP))
+        self.assertEqual(
+            self.current_twist.angular.z,
+            self._get_current_vel(self.twist_msg.angular.z, INIT_STEP))  # + 1 - 1
+
+    def test_joy_turbo_reset(self):
+        self._start_spinner_thread()
+
+        # Decrease
+        decrease_client = ActionClient(self.node, JoyTurbo, 'joy_turbo_decrease')
+        decrease_client.wait_for_server()
+        decrease_client.send_goal(JoyTurbo.Goal())
+
+        self.twist_msg.linear.x = 0.5
+        self.twist_msg.linear.y = 0.8
+        self.twist_msg.angular.z = 1.0
+
+        self._wait_for_twist()
+
+        self.assertEqual(
+            self.current_twist.linear.x,
+            self._get_current_vel(self.twist_msg.linear.x, INIT_STEP - 1))
+        self.assertEqual(
+            self.current_twist.linear.y,
+            self._get_current_vel(self.twist_msg.linear.y, INIT_STEP - 1))
+        self.assertEqual(
+            self.current_twist.angular.z,
+            self._get_current_vel(self.twist_msg.angular.z, INIT_STEP - 1))
+
+        self._reset_twist()
+
+        # Reset
+        reset_client = ActionClient(self.node, JoyTurbo, 'joy_turbo_reset')
+        reset_client.wait_for_server()
+        reset_client.send_goal(JoyTurbo.Goal())
+
+        self.twist_msg.linear.x = 0.5
+        self.twist_msg.linear.y = 0.8
+        self.twist_msg.angular.z = 1.0
+
+        self._wait_for_twist()
+
+        self.assertEqual(
+            self.current_twist.linear.x,
+            self._get_current_vel(self.twist_msg.linear.x, INIT_STEP))
+        self.assertEqual(
+            self.current_twist.linear.y,
+            self._get_current_vel(self.twist_msg.linear.y, INIT_STEP))
+        self.assertEqual(
+            self.current_twist.angular.z,
+            self._get_current_vel(self.twist_msg.angular.z, INIT_STEP))
+
+
+@launch_testing.post_shutdown_test()
+class TestProcessOutput(unittest.TestCase):
+    def test_exit_code(self, joystick_relay, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info, process=joystick_relay)

--- a/test/test_joystick_relay.py
+++ b/test/test_joystick_relay.py
@@ -131,6 +131,12 @@ class TestJoystickRelay(unittest.TestCase):
         self.twist_msg = Twist()
         self.current_twist = Twist()
 
+    @classmethod
+    def _set_twist(self, linear_x, linear_y, angular_z):
+        self.twist_msg.linear.x = linear_x
+        self.twist_msg.linear.y = linear_y
+        self.twist_msg.angular.z = angular_z
+
     def test_joy_priority_action(self):
         priority = None
 
@@ -160,9 +166,7 @@ class TestJoystickRelay(unittest.TestCase):
 
     def test_joy_vel(self):
         self._start_spinner_thread()
-        self.twist_msg.linear.x = 0.5
-        self.twist_msg.linear.y = 0.8
-        self.twist_msg.angular.z = 1.0
+        self._set_twist(0.5, 0.8, 1.0)
 
         self._wait_for_twist()
 
@@ -184,10 +188,7 @@ class TestJoystickRelay(unittest.TestCase):
         increase_client.wait_for_server()
         increase_client.send_goal(JoyTurbo.Goal())
 
-        self.twist_msg.linear.x = 0.5
-        self.twist_msg.linear.y = 0.8
-        self.twist_msg.angular.z = 1.0
-
+        self._set_twist(0.5, 0.8, 1.0)
         self._wait_for_twist()
 
         self.assertEqual(
@@ -207,10 +208,7 @@ class TestJoystickRelay(unittest.TestCase):
         decrease_client.wait_for_server()
         decrease_client.send_goal(JoyTurbo.Goal())
 
-        self.twist_msg.linear.x = 0.5
-        self.twist_msg.linear.y = 0.8
-        self.twist_msg.angular.z = 1.0
-
+        self._set_twist(0.5, 0.8, 1.0)
         self._wait_for_twist()
 
         self.assertEqual(
@@ -231,10 +229,7 @@ class TestJoystickRelay(unittest.TestCase):
         client.wait_for_server()
         client.send_goal(JoyTurbo.Goal())
 
-        self.twist_msg.linear.x = 0.5
-        self.twist_msg.linear.y = 0.8
-        self.twist_msg.angular.z = 1.0
-
+        self._set_twist(0.5, 0.8, 1.0)
         self._wait_for_twist()
 
         self.assertEqual(
@@ -254,10 +249,7 @@ class TestJoystickRelay(unittest.TestCase):
         client.wait_for_server()
         client.send_goal(JoyTurbo.Goal())
 
-        self.twist_msg.linear.x = 0.5
-        self.twist_msg.linear.y = 0.8
-        self.twist_msg.angular.z = 1.0
-
+        self._set_twist(0.5, 0.8, 1.0)
         self._wait_for_twist()
 
         self.assertEqual(
@@ -278,10 +270,7 @@ class TestJoystickRelay(unittest.TestCase):
         decrease_client.wait_for_server()
         decrease_client.send_goal(JoyTurbo.Goal())
 
-        self.twist_msg.linear.x = 0.5
-        self.twist_msg.linear.y = 0.8
-        self.twist_msg.angular.z = 1.0
-
+        self._set_twist(0.5, 0.8, 1.0)
         self._wait_for_twist()
 
         self.assertEqual(
@@ -301,10 +290,7 @@ class TestJoystickRelay(unittest.TestCase):
         reset_client.wait_for_server()
         reset_client.send_goal(JoyTurbo.Goal())
 
-        self.twist_msg.linear.x = 0.5
-        self.twist_msg.linear.y = 0.8
-        self.twist_msg.angular.z = 1.0
-
+        self._set_twist(0.5, 0.8, 1.0)
         self._wait_for_twist()
 
         self.assertEqual(

--- a/test/test_joystick_relay.py
+++ b/test/test_joystick_relay.py
@@ -265,7 +265,7 @@ class TestJoystickRelay(unittest.TestCase):
     def test_joy_turbo_reset(self):
         self._start_spinner_thread()
 
-        # Decrease
+        # Decrease first to see the effect of the reset
         decrease_client = ActionClient(self.node, JoyTurbo, 'joy_turbo_decrease')
         decrease_client.wait_for_server()
         decrease_client.send_goal(JoyTurbo.Goal())


### PR DESCRIPTION
`joystick_relay` was halfway ported in https://github.com/ros-teleop/twist_mux/pull/25. 

This PR completes the migration and enables it when launching `twist_mux`.

I also added some tests.