### PR TITLE
Change license to Apache-2.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,7 @@
   <author email="efernandez@clearpathrobotics.com">Enrique Fernandez</author>
   <author email="siegfried.gevatter@pal-robotics.com">Siegfried-A. Gevatter Pujals</author>
 
-  <license>CC BY-NC-SA 4.0</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 


### PR DESCRIPTION
As @bmagyar did in https://github.com/ros-teleop/twist_mux/commit/c6d4926b7bcf80a66d5118445bce33c84d431180 , I suggest changing the license of this package to Apache 2.0, which is friendly even for commercial usage. It seems to me that if the change was ok for PAL robotics for ROS 2, it could also be okay for ROS 1.

I think this PR requires someone from PAL robotics to give an ack.