### PR TITLE
Add missing use_sim_time param for joystick_relay

### DIFF
--- a/launch/twist_mux_launch.py
+++ b/launch/twist_mux_launch.py
@@ -78,5 +78,7 @@ def generate_launch_description():
             output='screen',
             remappings={('joy_vel_in', 'input_joy/cmd_vel'),
                         ('joy_vel_out', 'joy_vel')},
-            parameters=[LaunchConfiguration('config_joy')])
+            parameters=[
+                {'use_sim_time': LaunchConfiguration('use_sim_time')},
+                LaunchConfiguration('config_joy')])
     ])


### PR DESCRIPTION
Following https://github.com/ros-teleop/twist_mux/pull/41, this PR is for adding the use_sim_time parameter to the node joystick_relay in the launch file.