### PR TITLE
TwistStamped Support

### DIFF
--- a/include/twist_mux/topic_handle.hpp
+++ b/include/twist_mux/topic_handle.hpp
@@ -39,6 +39,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 
 #include <twist_mux/utils.hpp>
 #include <twist_mux/twist_mux.hpp>
@@ -195,6 +196,48 @@ public:
     // all the topic list; so far there's no O(1) solution.
     if (mux_->hasPriority(*this)) {
       mux_->publishTwist(msg);
+    }
+  }
+};
+
+class VelocityStampedTopicHandle : public TopicHandle_<geometry_msgs::msg::TwistStamped>
+{
+private:
+  typedef TopicHandle_<geometry_msgs::msg::TwistStamped> base_type;
+
+  // https://index.ros.org/doc/ros2/About-Quality-of-Service-Settings
+  // rmw_qos_profile_t twist_qos_profile = rmw_qos_profile_sensor_data;
+
+public:
+  typedef typename base_type::priority_type priority_type;
+
+  VelocityStampedTopicHandle(
+    const std::string & name, const std::string & topic, const rclcpp::Duration & timeout,
+    priority_type priority, TwistMux * mux)
+  : base_type(name, topic, timeout, priority, mux)
+  {
+    subscriber_ = mux_->create_subscription<geometry_msgs::msg::TwistStamped>(
+      topic_, rclcpp::SystemDefaultsQoS(),
+      std::bind(&VelocityStampedTopicHandle::callback, this, std::placeholders::_1));
+  }
+
+  bool isMasked(priority_type lock_priority) const
+  {
+    // std::cout << hasExpired() << " / " << (getPriority() < lock_priority) << std::endl;
+    return hasExpired() || (getPriority() < lock_priority);
+  }
+
+  void callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    stamp_ = mux_->now();
+    msg_ = *msg;
+
+    // Check if this twist has priority.
+    // Note that we have to check all the locks because they might time out
+    // and since we have several topics we must look for the highest one in
+    // all the topic list; so far there's no O(1) solution.
+    if (mux_->hasPriorityStamped(*this)) {
+      mux_->publishTwistStamped(msg);
     }
   }
 };

--- a/include/twist_mux/topic_handle.hpp
+++ b/include/twist_mux/topic_handle.hpp
@@ -159,9 +159,6 @@ class VelocityTopicHandle : public TopicHandle_<geometry_msgs::msg::Twist>
 private:
   typedef TopicHandle_<geometry_msgs::msg::Twist> base_type;
 
-  // https://index.ros.org/doc/ros2/About-Quality-of-Service-Settings
-  // rmw_qos_profile_t twist_qos_profile = rmw_qos_profile_sensor_data;
-
 public:
   typedef typename base_type::priority_type priority_type;
 
@@ -173,10 +170,6 @@ public:
     subscriber_ = mux_->create_subscription<geometry_msgs::msg::Twist>(
       topic_, rclcpp::SystemDefaultsQoS(),
       std::bind(&VelocityTopicHandle::callback, this, std::placeholders::_1));
-
-    // subscriber_ = nh_.create_subscription<geometry_msgs::msg::Twist>(
-    //    topic_, twist_qos_profile,
-    //  std::bind(&VelocityTopicHandle::callback, this, std::placeholders::_1));
   }
 
   bool isMasked(priority_type lock_priority) const
@@ -205,9 +198,6 @@ class VelocityStampedTopicHandle : public TopicHandle_<geometry_msgs::msg::Twist
 private:
   typedef TopicHandle_<geometry_msgs::msg::TwistStamped> base_type;
 
-  // https://index.ros.org/doc/ros2/About-Quality-of-Service-Settings
-  // rmw_qos_profile_t twist_qos_profile = rmw_qos_profile_sensor_data;
-
 public:
   typedef typename base_type::priority_type priority_type;
 
@@ -223,7 +213,6 @@ public:
 
   bool isMasked(priority_type lock_priority) const
   {
-    // std::cout << hasExpired() << " / " << (getPriority() < lock_priority) << std::endl;
     return hasExpired() || (getPriority() < lock_priority);
   }
 
@@ -246,9 +235,6 @@ class LockTopicHandle : public TopicHandle_<std_msgs::msg::Bool>
 {
 private:
   typedef TopicHandle_<std_msgs::msg::Bool> base_type;
-
-  // https://index.ros.org/doc/ros2/About-Quality-of-Service-Settings
-  // rmw_qos_profile_t lock_qos_profile = rmw_qos_profile_sensor_data;
 
 public:
   typedef typename base_type::priority_type priority_type;

--- a/include/twist_mux/twist_mux.hpp
+++ b/include/twist_mux/twist_mux.hpp
@@ -38,6 +38,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 
 #include <list>
 #include <memory>
@@ -51,6 +52,7 @@ namespace twist_mux
 class TwistMuxDiagnostics;
 struct TwistMuxDiagnosticsStatus;
 class VelocityTopicHandle;
+class VelocityStampedTopicHandle;
 class LockTopicHandle;
 
 /**
@@ -64,6 +66,7 @@ public:
   using handle_container = std::list<T>;
 
   using velocity_topic_container = handle_container<VelocityTopicHandle>;
+  using velocity_stamped_topic_container = handle_container<VelocityStampedTopicHandle>;
   using lock_topic_container = handle_container<LockTopicHandle>;
 
   TwistMux();
@@ -73,7 +76,11 @@ public:
 
   bool hasPriority(const VelocityTopicHandle & twist);
 
+  bool hasPriorityStamped(const VelocityStampedTopicHandle & twist);
+
   void publishTwist(const geometry_msgs::msg::Twist::ConstSharedPtr & msg);
+
+  void publishTwistStamped(const geometry_msgs::msg::TwistStamped::ConstSharedPtr & msg);
 
   void updateDiagnostics();
 
@@ -92,11 +99,14 @@ protected:
    * must reserve the number of handles initially.
    */
   std::shared_ptr<velocity_topic_container> velocity_hs_;
+  std::shared_ptr<velocity_stamped_topic_container> velocity_stamped_hs_;
   std::shared_ptr<lock_topic_container> lock_hs_;
 
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr cmd_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr cmd_pub_stamped_;
 
   geometry_msgs::msg::Twist last_cmd_;
+  geometry_msgs::msg::TwistStamped last_cmd_stamped_;
 
   template<typename T>
   void getTopicHandles(const std::string & param_name, handle_container<T> & topic_hs);

--- a/include/twist_mux/twist_mux_diagnostics_status.hpp
+++ b/include/twist_mux/twist_mux_diagnostics_status.hpp
@@ -66,7 +66,7 @@ struct TwistMuxDiagnosticsStatus
     last_loop_update(rclcpp::Clock().now()),
     main_loop_time(0),
     priority(0),
-    use_stamped(false)
+    use_stamped(true)
   {
     velocity_hs = std::make_shared<TwistMux::velocity_topic_container>();
     velocity_stamped_hs = std::make_shared<TwistMux::velocity_stamped_topic_container>();

--- a/include/twist_mux/twist_mux_diagnostics_status.hpp
+++ b/include/twist_mux/twist_mux_diagnostics_status.hpp
@@ -55,16 +55,21 @@ struct TwistMuxDiagnosticsStatus
 
   LockTopicHandle::priority_type priority;
 
+  bool use_stamped;
+
   std::shared_ptr<TwistMux::velocity_topic_container> velocity_hs;
+  std::shared_ptr<TwistMux::velocity_stamped_topic_container> velocity_stamped_hs;
   std::shared_ptr<TwistMux::lock_topic_container> lock_hs;
 
   TwistMuxDiagnosticsStatus()
   : reading_age(0),
     last_loop_update(rclcpp::Clock().now()),
     main_loop_time(0),
-    priority(0)
+    priority(0),
+    use_stamped(false)
   {
     velocity_hs = std::make_shared<TwistMux::velocity_topic_container>();
+    velocity_stamped_hs = std::make_shared<TwistMux::velocity_stamped_topic_container>();
     lock_hs = std::make_shared<TwistMux::lock_topic_container>();
   }
 };

--- a/src/twist_marker.cpp
+++ b/src/twist_marker.cpp
@@ -87,19 +87,6 @@ public:
     }
   }
 
-  void update(const geometry_msgs::msg::TwistStamped & twist)
-  {
-    using std::abs;
-
-    marker_.points[1].x = twist.twist.linear.x;
-
-    if (abs(twist.twist.linear.y) > abs(twist.twist.angular.z)) {
-      marker_.points[1].y = twist.twist.linear.y;
-    } else {
-      marker_.points[1].y = twist.twist.angular.z;
-    }
-  }
-
   const visualization_msgs::msg::Marker & getMarker()
   {
     return marker_;

--- a/src/twist_marker.cpp
+++ b/src/twist_marker.cpp
@@ -34,6 +34,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -86,6 +87,19 @@ public:
     }
   }
 
+  void update(const geometry_msgs::msg::TwistStamped & twist)
+  {
+    using std::abs;
+
+    marker_.points[1].x = twist.twist.linear.x;
+
+    if (abs(twist.twist.linear.y) > abs(twist.twist.angular.z)) {
+      marker_.points[1].y = twist.twist.linear.y;
+    } else {
+      marker_.points[1].y = twist.twist.angular.z;
+    }
+  }
+
   const visualization_msgs::msg::Marker & getMarker()
   {
     return marker_;
@@ -107,21 +121,33 @@ public:
   {
     std::string frame_id;
     double scale;
+    bool use_stamped;
     double z;
 
     this->declare_parameter("frame_id", "base_footprint");
     this->declare_parameter("scale", 1.0);
+    this->declare_parameter("use_stamped", false);
     this->declare_parameter("vertical_position", 2.0);
 
     this->get_parameter<std::string>("frame_id", frame_id);
     this->get_parameter<double>("scale", scale);
+    this->get_parameter<bool>("use_stamped", use_stamped);
     this->get_parameter<double>("vertical_position", z);
 
     marker_ = std::make_shared<TwistMarker>(frame_id, scale, z);
 
-    sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
-      "twist", rclcpp::SystemDefaultsQoS(),
-      std::bind(&TwistMarkerPublisher::callback, this, std::placeholders::_1));
+    if (use_stamped)
+    {
+      sub_stamped_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+        "twist", rclcpp::SystemDefaultsQoS(),
+        std::bind(&TwistMarkerPublisher::callback_stamped, this, std::placeholders::_1));
+    }
+    else
+    {
+      sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
+        "twist", rclcpp::SystemDefaultsQoS(),
+        std::bind(&TwistMarkerPublisher::callback, this, std::placeholders::_1));
+    }
 
     pub_ =
       this->create_publisher<visualization_msgs::msg::Marker>(
@@ -136,8 +162,16 @@ public:
     pub_->publish(marker_->getMarker());
   }
 
+  void callback_stamped(const geometry_msgs::msg::TwistStamped::ConstSharedPtr twist)
+  {
+    marker_->update(twist->twist);
+
+    pub_->publish(marker_->getMarker());
+  }
+
 private:
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr sub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_stamped_;
   rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr pub_;
 
   std::shared_ptr<TwistMarker> marker_ = nullptr;

--- a/src/twist_mux_diagnostics.cpp
+++ b/src/twist_mux_diagnostics.cpp
@@ -58,11 +58,13 @@ void TwistMuxDiagnostics::update()
 void TwistMuxDiagnostics::updateStatus(const status_type::ConstPtr & status)
 {
   status_->velocity_hs = status->velocity_hs;
+  status_->velocity_stamped_hs = status->velocity_stamped_hs;
   status_->lock_hs = status->lock_hs;
   status_->priority = status->priority;
 
   status_->main_loop_time = status->main_loop_time;
   status_->reading_age = status->reading_age;
+  status_->use_stamped = status->use_stamped;
 
   update();
 }
@@ -78,12 +80,25 @@ void TwistMuxDiagnostics::diagnostics(diagnostic_updater::DiagnosticStatusWrappe
     stat.summary(OK, "ok");
   }
 
-  for (auto & velocity_h : *status_->velocity_hs) {
-    stat.addf(
-      "velocity " + velocity_h.getName(), " %s (listening to %s @ %fs with priority #%d)",
-      (velocity_h.isMasked(status_->priority) ? "masked" : "unmasked"),
-      velocity_h.getTopic().c_str(),
-      velocity_h.getTimeout().seconds(), static_cast<int>(velocity_h.getPriority()));
+  if(status_->use_stamped)
+  {
+    for (auto & velocity_stamped_h : *status_->velocity_stamped_hs) {
+      stat.addf(
+        "velocity " + velocity_stamped_h.getName(), " %s (listening to %s @ %fs with priority #%d)",
+        (velocity_stamped_h.isMasked(status_->priority) ? "masked" : "unmasked"),
+        velocity_stamped_h.getTopic().c_str(),
+        velocity_stamped_h.getTimeout().seconds(), static_cast<int>(velocity_stamped_h.getPriority()));
+    }
+  }
+  else
+  {
+    for (auto & velocity_h : *status_->velocity_hs) {
+      stat.addf(
+        "velocity " + velocity_h.getName(), " %s (listening to %s @ %fs with priority #%d)",
+        (velocity_h.isMasked(status_->priority) ? "masked" : "unmasked"),
+        velocity_h.getTopic().c_str(),
+        velocity_h.getTimeout().seconds(), static_cast<int>(velocity_h.getPriority()));
+    }
   }
 
   for (const auto & lock_h : *status_->lock_hs) {


### PR DESCRIPTION
Added support for `TwistStamped` support using parameter `use_stamped` to maintain support for unstamped `Twist` messages.

If parameter is enabled, all `Twist` message topic publishers and subscribers are switched to `TwistStamped` topics. 

