### PR TITLE
Set twist_marker/use_stamped to default true, to match twist_mux

### DIFF
--- a/src/twist_marker.cpp
+++ b/src/twist_marker.cpp
@@ -108,12 +108,12 @@ public:
   {
     std::string frame_id;
     double scale;
-    bool use_stamped;
+    bool use_stamped = true;
     double z;
 
     this->declare_parameter("frame_id", "base_footprint");
     this->declare_parameter("scale", 1.0);
-    this->declare_parameter("use_stamped", false);
+    this->declare_parameter("use_stamped", true);
     this->declare_parameter("vertical_position", 2.0);
 
     this->get_parameter<std::string>("frame_id", frame_id);

--- a/src/twist_mux.cpp
+++ b/src/twist_mux.cpp
@@ -78,7 +78,9 @@ TwistMux::TwistMux()
 void TwistMux::init()
 {
   // Get use stamped parameter
-  bool use_stamped;
+  bool use_stamped = false;
+  this->declare_parameter("use_stamped", use_stamped);
+
   auto nh = std::shared_ptr<rclcpp::Node>(this, [](rclcpp::Node *) {});
   fetch_param(nh, "use_stamped", use_stamped);
 

--- a/src/twist_mux.cpp
+++ b/src/twist_mux.cpp
@@ -78,7 +78,7 @@ TwistMux::TwistMux()
 void TwistMux::init()
 {
   // Get use stamped parameter
-  bool use_stamped = false;
+  bool use_stamped = true;
   this->declare_parameter("use_stamped", use_stamped);
 
   auto nh = std::shared_ptr<rclcpp::Node>(this, [](rclcpp::Node *) {});


### PR DESCRIPTION
Something I noticed when updating the workspace I've been using for my hobby projects. The `use_stamped` parameter in `twist_marker` is defaulting to `false`, but the same parameter in `twist_mux` must be explicitly set or the node will throw an exception and die. 

I'm making an assumption that when `use_stamped` was added to the `twist_mux` node, it was intentionally added without a default value to force developers to evaluate their usage of the node. I actually agree with that direction, if that was the intention, but at the same time it's pretty annoying that the two nodes in this package have different behaviours where one is optional and the other is not. 

This PR changes `/twist_mux/use_stamped` to default to `false` when the node is created, and declares it as a parameter for `twist_mux` instead of just blindly looking in the global namespace. 

There is also the matter that [Steve M brought up regarding the default value of this parameter with Nav2. ](https://github.com/ros-teleop/twist_mux/issues/54). I don't address that issue here, it's orthoganal to the merits of having a parameter act uniformly across the package.