### PR TITLE
Fix regression: do not automatically declare "use_stamped" as it can cause an exception to be raised.

### DIFF
--- a/src/twist_mux.cpp
+++ b/src/twist_mux.cpp
@@ -79,10 +79,11 @@ void TwistMux::init()
 {
   // Get use stamped parameter
   bool use_stamped = true;
-  this->declare_parameter("use_stamped", use_stamped);
 
   auto nh = std::shared_ptr<rclcpp::Node>(this, [](rclcpp::Node *) {});
-  fetch_param(nh, "use_stamped", use_stamped);
+
+  if (!nh->get_parameter("use_stamped", use_stamped))
+    RCLCPP_INFO(nh->get_logger(), "\"use_stamped\" is not declared as parameter, defaulting to \"true\".");
 
   /// Get topics and locks:
   if(use_stamped)


### PR DESCRIPTION
This fixes #60.