### PR TITLE
migrate from removed ament_target_dependencies to modern CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 project(twist_mux)
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -17,33 +17,33 @@ find_package(geometry_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(diagnostic_updater REQUIRED)
 
-include_directories(include)
-
-set(
-  DEPENDENCIES
-  "rclcpp"
-  "std_msgs"
-  "geometry_msgs"
-  "visualization_msgs"
-  "diagnostic_updater"
-)
-
 add_executable(twist_mux
   src/twist_mux.cpp
   src/twist_mux_node.cpp
   src/twist_mux_diagnostics.cpp
 )
-ament_target_dependencies(twist_mux ${DEPENDENCIES})
+target_include_directories(twist_mux PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(twist_mux
+  ${rclcpp_TARGETS}
+  ${std_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
+  ${diagnostic_updater_TARGETS}
+)
 
 add_executable(twist_marker
   src/twist_marker.cpp
 )
-ament_target_dependencies(twist_marker ${DEPENDENCIES})
+target_link_libraries(twist_marker
+  ${rclcpp_TARGETS}
+  ${geometry_msgs_TARGETS}
+  ${visualization_msgs_TARGETS}
+)
 
 install(
   TARGETS twist_mux twist_marker
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
@@ -69,6 +69,12 @@ endif()
 
 ament_export_include_directories(include)
 
-ament_export_dependencies(${DEPENDENCIES})
+ament_export_dependencies(
+  rclcpp
+  std_msgs
+  geometry_msgs
+  visualization_msgs
+  diagnostic_updater
+)
 
 ament_package()


### PR DESCRIPTION
fixes #66 

FYI @akupferb @mathias-luedtke