### PR TITLE
Pin rolling binary build to Ubuntu Noble during Resolute transition

### DIFF
--- a/.github/workflows/rolling-binary-build-main.yml
+++ b/.github/workflows/rolling-binary-build-main.yml
@@ -22,5 +22,6 @@ jobs:
     with:
       ros_distro: rolling
       ros_repo: main
+      os_code_name: noble
       upstream_workspace: twist_mux_deps.repos
       ref_for_scheduled_build: rolling


### PR DESCRIPTION
industrial_ci@master now resolves `ROS_DISTRO=rolling` to `ubuntu:resolute`, but the buildfarm has not published `ros-rolling-*` packages for Resolute yet, so the rolling job fails at `E: Unable to locate package ros-rolling-ros-environment`.

REP-2000 still lists Noble (24.04) as Rolling's target platform, so this pins `os_code_name: noble` for the rolling binary build until Resolute packages land. Humble and Iron are unaffected.

The same failure is visible on the `rolling` branch's scheduled build, confirming it is an upstream transition issue rather than a code change.